### PR TITLE
Bumping up the year in the license file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+language: node_js
+node_js:
+  - 'iojs'
+  - '0.12'
+  - '0.10'

--- a/license.md
+++ b/license.md
@@ -1,7 +1,7 @@
 License (MIT)
 -------------
 
-Copyright (c) 2013 <%= github_username %>
+Copyright (c) 2015 <%= github_username %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/license.md
+++ b/license.md
@@ -1,7 +1,7 @@
 License (MIT)
 -------------
 
-Copyright (c) 2015 <%= github_username %>
+Copyright (c) 2015 Carrot Creative
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/root/license.md
+++ b/root/license.md
@@ -1,7 +1,6 @@
-License (MIT)
--------------
+# License (MIT)
 
-Copyright (c) 2013 <%= github_username %>
+Copyright (c)<% var d = new Date(); -%> <%= d.getFullYear(); %> <%= github_username %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/root/test/test.coffee
+++ b/root/test/test.coffee
@@ -9,7 +9,7 @@ opts =
   config: path.join(_path, 'locals.json')
 
 before ->
-  sprout.add(tpl, test_template_path, {verbose: true})
+  sprout.add(tpl, test_template_path)
   .then -> rimraf.sync(test_path)
   .then -> sprout.init(tpl, test_path, opts)
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -9,18 +9,18 @@ opts =
   config: path.join(_path, 'locals.json')
 
 before ->
-  sprout.add(tpl, test_template_path, {verbose: true})
+  sprout.add(tpl, test_template_path)
   .then -> rimraf.sync(test_path)
   .then -> sprout.init(tpl, test_path, opts)
+
 after ->
   sprout.remove(tpl)
   .then -> rimraf.sync(test_path)
 
-describe 'sprout.init', ->
-  it 'properly creates new project from locals', (done) ->
+describe 'init', ->
+  it 'creates generates readme', (done) ->
     tgt = path.join(test_path, 'readme.md')
-    fs.existsSync(tgt).should.be.true
-
+    fs.existsSync(tgt).should.be.ok
     contents = fs.readFileSync(tgt, 'utf8')
     contents.should.match /# project x/
     done()
@@ -28,4 +28,19 @@ describe 'sprout.init', ->
   it 'removes .travis.yml when travis option is false', (done) ->
     tgt = path.join(test_path, '.travis.yml')
     fs.existsSync(tgt).should.be.false
+    done()
+
+  it 'creates a test.coffee', (done) ->
+    tgt = path.join(test_path, 'test', 'test.coffee')
+    fs.existsSync(tgt).should.be.ok
+    contents = fs.readFileSync(tgt, 'utf8')
+    contents.should.match /test-project-x/
+    done()
+
+  it 'generates a license', (done) ->
+    d = new Date()
+    tgt = path.join(test_path, 'license.md')
+    fs.existsSync(tgt).should.be.ok
+    contents = fs.readFileSync(tgt, 'utf8')
+    contents.should.match(new RegExp(d.getFullYear()))
     done()


### PR DESCRIPTION
Stumbled into this, figured I'd bump it up, as anyone using this is going to be in the year 2015.

Can we actually have sprout get the current year?  That would actually be better than this quick fix -- but this should keep us good until 2016.
